### PR TITLE
Switch to new Vagrant Ansible Local Provisioner

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,8 +14,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     cd.vm.network :forwarded_port, host: 5000, guest: 5000
     cd.vm.network :forwarded_port, host: 2201, guest: 22, id: "ssh", auto_correct: true
     cd.vm.network "private_network", ip: "192.168.50.91"
-    cd.vm.provision "shell", path: "bootstrap.sh"
-    cd.vm.provision :shell, inline: 'ansible-playbook /vagrant/ansible/cd.yml -c local'
+    cd.vm.provision "ansible_local" do |ansible|
+      ansible.playbook = "ansible/cd.yml"
+    end
     cd.vm.hostname = "cd"
   end
   config.vm.define :prod do |prod|

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-echo "Installing Ansible..."
-apt-get install -y software-properties-common
-apt-add-repository ppa:ansible/ansible
-apt-get update
-apt-get install -y ansible


### PR DESCRIPTION
@vfarcic I successfully used your nice environment to validate the upcoming `ansible_local` vagrant provisioner (https://github.com/mitchellh/vagrant/pull/5340).

So as of Vagrant 1.8+ (not released yet), this little change could make sense. If you are interested in this Vagrant feature, please feel free to add your feedbacks to https://github.com/mitchellh/vagrant/issues/2103 :smile:.
