### PR TITLE
Changed state=running -> state=started (to avoid ansible/docker error)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     cd.vm.network :forwarded_port, host: 5000, guest: 5000
     cd.vm.network :forwarded_port, host: 2201, guest: 22, id: "ssh", auto_correct: true
     cd.vm.network "private_network", ip: "192.168.50.91"
+    # added dynamic swap file management to prevent "Free Swap Space: 0 B" warning in Jenkins
+    cd.vm.provision :shell, inline: 'apt-get install swapspace -y'
     cd.vm.provision "shell", path: "bootstrap.sh"
     cd.vm.provision :shell, inline: 'ansible-playbook /vagrant/ansible/cd.yml -c local -v'
     cd.vm.hostname = "cd"

--- a/ansible/roles/books-service/tasks/main.yml
+++ b/ansible/roles/books-service/tasks/main.yml
@@ -21,5 +21,5 @@
     image=192.168.50.91:5000/books-service
     ports=9001:8080
     volumes=/data/books-service/db:/data/db
-    state=running
+    state=started
   tags: [books-service]


### PR DESCRIPTION
This change prevents a fatal error occurring when in the docker/tests/Dockerfile is being executed. I haven;t been able to trace the exact cause of this, but I have the impression that there could be a discrepancy between "state" definition and/or values in the Docker remote API and docker-ansible plugin. Either way, this change fixes the problem.

The change in the Vagrantfile prevents a warning in Jenkins and is cosmetic in nature.  

See also longer explanation of "books-service" issues at https://technologyconversations.com/2015/02/11/continuous-integration-delivery-or-deployment-with-jenkins-docker-and-ansible/comment-page-1/#comment-12095
